### PR TITLE
firmware: add conditional compilation to prevent errors

### DIFF
--- a/firmware/fw_base.S
+++ b/firmware/fw_base.S
@@ -29,6 +29,7 @@ _start:
 	li	ra, 0
 	call	_reset_regs
 
+#ifdef FW_DYNAMIC
 	/* Allow main firmware to save info */
 	add	s0, a0, zero
 	add	s1, a1, zero
@@ -41,6 +42,7 @@ _start:
 	add	a2, s2, zero
 	add	a3, s3, zero
 	add	a4, s4, zero
+#endif
 
 	/* Preload HART details
 	 * s7 -> HART Count

--- a/firmware/objects.mk
+++ b/firmware/objects.mk
@@ -18,6 +18,7 @@ firmware-genflags-y += -DFW_TEXT_START=$(FW_TEXT_START)
 endif
 
 firmware-bins-$(FW_DYNAMIC) += fw_dynamic.bin
+firmware-genflags-$(FW_DYNAMIC) += -DFW_DYNAMIC
 
 firmware-bins-$(FW_JUMP) += fw_jump.bin
 ifdef FW_JUMP_ADDR


### PR DESCRIPTION
The fw_save_info function can only be called when FW_DYNAMIC, in other cases the
call may go wrong, accessing unknown memory or not having the correct magic to
stop the program in _bad_dynamic_info

Signed-off-by: Xiang Wang <wxjstz@126.com>